### PR TITLE
Add etcd port for alluxiofs

### DIFF
--- a/alluxiofs/__init__.py
+++ b/alluxiofs/__init__.py
@@ -1,1 +1,3 @@
 from .core import AlluxioFileSystem
+
+__all__ = ["AlluxioFileSystem"]

--- a/alluxiofs/core.py
+++ b/alluxiofs/core.py
@@ -42,6 +42,7 @@ class AlluxioFileSystem(AbstractFileSystem):
         logger=None,
         concurrency=64,
         http_port="28080",
+        etcd_port="2379",
         preload_path=None,
         target_protocol=None,
         target_options=None,
@@ -79,6 +80,7 @@ class AlluxioFileSystem(AbstractFileSystem):
                 logger,
                 concurrency,
                 http_port,
+                etcd_port,
             )
             if preload_path is not None:
                 self.alluxio.load(preload_path)


### PR DESCRIPTION
Enable the etcd port for the latest alluxio python client in the alluxiofs.