### PR TITLE
Remove Alluxio as dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "fsspec",
-        "alluxio",
     ],
     extras_require={"tests": ["pytest"]},
     python_requires=">=3.8",


### PR DESCRIPTION
Will add back after we decide the naming for alluxio-py pip packaging
https://github.com/Alluxio/alluxio-py
