### PR TITLE
Fix the bug after introducing ufs full path as page id

### DIFF
--- a/alluxiofs/client/const.py
+++ b/alluxiofs/client/const.py
@@ -23,17 +23,13 @@ ALLUXIO_SUCCESS_IDENTIFIER = "success"
 ALLUXIO_COMMON_EXTENSION_ENABLE = "alluxio.common.extension.enable"
 ALLUXIO_COMMON_ONDEMANDPOOL_DISABLE = "alluxio.common.ondemandpool.disable"
 LIST_URL_FORMAT = "http://{worker_host}:{http_port}/v1/files"
-FULL_PAGE_URL_FORMAT = (
-    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
+FULL_PAGE_URL_FORMAT = "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
+PAGE_URL_FORMAT = (
+    "http://{worker_host}:{http_port}/v1/file/{path_id}"
+    "/page/{page_index}?offset={page_offset}&length={page_length}&ufsFullPath={file_path}"
 )
-PAGE_URL_FORMAT = ("http://{worker_host}:{http_port}/v1/file/{path_id}"
-                   "/page/{page_index}?offset={page_offset}&length={page_length}&ufsFullPath={file_path}")
-WRITE_PAGE_URL_FORMAT = (
-    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
-)
-PAGE_PATH_URL_FORMAT = (
-    "/v1/file/{path_id}/page/{page_index}"
-)
+WRITE_PAGE_URL_FORMAT = "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
+PAGE_PATH_URL_FORMAT = "/v1/file/{path_id}/page/{page_index}"
 GET_FILE_STATUS_URL_FORMAT = "http://{worker_host}:{http_port}/v1/info"
 LOAD_URL_FORMAT = "http://{worker_host}:{http_port}/v1/load"
 # TODO (chunxu): Remove the concrete types of LOAD formats. Keep them for asyncio.

--- a/alluxiofs/client/const.py
+++ b/alluxiofs/client/const.py
@@ -24,11 +24,12 @@ ALLUXIO_COMMON_EXTENSION_ENABLE = "alluxio.common.extension.enable"
 ALLUXIO_COMMON_ONDEMANDPOOL_DISABLE = "alluxio.common.ondemandpool.disable"
 LIST_URL_FORMAT = "http://{worker_host}:{http_port}/v1/files"
 FULL_PAGE_URL_FORMAT = (
-    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}"
+    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
 )
-PAGE_URL_FORMAT = "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?offset={page_offset}&length={page_length}"
+PAGE_URL_FORMAT = ("http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}"
+                   "?offset={page_offset}&length={page_length}&ufsFullPath={file_path}")
 WRITE_PAGE_URL_FORMAT = (
-    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}"
+    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}/?ufsFullPath={file_path}"
 )
 GET_FILE_STATUS_URL_FORMAT = "http://{worker_host}:{http_port}/v1/info"
 LOAD_URL_FORMAT = "http://{worker_host}:{http_port}/v1/load"

--- a/alluxiofs/client/const.py
+++ b/alluxiofs/client/const.py
@@ -26,13 +26,13 @@ LIST_URL_FORMAT = "http://{worker_host}:{http_port}/v1/files"
 FULL_PAGE_URL_FORMAT = (
     "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
 )
-PAGE_URL_FORMAT = ("http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}"
-                   "?offset={page_offset}&length={page_length}&ufsFullPath={file_path}")
+PAGE_URL_FORMAT = ("http://{worker_host}:{http_port}/v1/file/{path_id}"
+                   "/page/{page_index}?offset={page_offset}&length={page_length}&ufsFullPath={file_path}")
 WRITE_PAGE_URL_FORMAT = (
-    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}/?ufsFullPath={file_path}"
+    "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
 )
 PAGE_PATH_URL_FORMAT = (
-    "/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
+    "/v1/file/{path_id}/page/{page_index}"
 )
 GET_FILE_STATUS_URL_FORMAT = "http://{worker_host}:{http_port}/v1/info"
 LOAD_URL_FORMAT = "http://{worker_host}:{http_port}/v1/load"

--- a/alluxiofs/client/const.py
+++ b/alluxiofs/client/const.py
@@ -31,6 +31,9 @@ PAGE_URL_FORMAT = ("http://{worker_host}:{http_port}/v1/file/{path_id}/page/{pag
 WRITE_PAGE_URL_FORMAT = (
     "http://{worker_host}:{http_port}/v1/file/{path_id}/page/{page_index}/?ufsFullPath={file_path}"
 )
+PAGE_PATH_URL_FORMAT = (
+    "/v1/file/{path_id}/page/{page_index}?ufsFullPath={file_path}"
+)
 GET_FILE_STATUS_URL_FORMAT = "http://{worker_host}:{http_port}/v1/info"
 LOAD_URL_FORMAT = "http://{worker_host}:{http_port}/v1/load"
 # TODO (chunxu): Remove the concrete types of LOAD formats. Keep them for asyncio.

--- a/alluxiofs/client/core.py
+++ b/alluxiofs/client/core.py
@@ -530,13 +530,13 @@ class AlluxioClient:
             if self.data_manager:
                 return b"".join(
                     self._all_page_generator_alluxiocommon(
-                        worker_host, worker_http_port, path_id
+                        worker_host, worker_http_port, path_id, file_path
                     )
                 )
             else:
                 return b"".join(
                     self._all_page_generator(
-                        worker_host, worker_http_port, path_id
+                        worker_host, worker_http_port, path_id, file_path
                     )
                 )
         except Exception as e:
@@ -583,12 +583,12 @@ class AlluxioClient:
         try:
             if self.data_manager:
                 return self._range_page_generator_alluxiocommon(
-                    worker_host, worker_http_port, path_id, offset, length
+                    worker_host, worker_http_port, path_id, file_path, offset, length
                 )
             else:
                 return b"".join(
                     self._range_page_generator(
-                        worker_host, worker_http_port, path_id, offset, length
+                        worker_host, worker_http_port, path_id, file_path, offset, length
                     )
                 )
         except Exception as e:
@@ -620,6 +620,7 @@ class AlluxioClient:
                     worker_host=worker_host,
                     http_port=worker_http_port,
                     path_id=path_id,
+                    file_path=file_path,
                     page_index=page_index,
                 ),
                 headers={"Content-Type": "application/octet-stream"},
@@ -633,7 +634,7 @@ class AlluxioClient:
             )
 
     def _all_page_generator_alluxiocommon(
-        self, worker_host, worker_http_port, path_id
+        self, worker_host, worker_http_port, path_id, file_path
     ):
         page_index = 0
         fetching_pages_num_each_round = 4
@@ -645,6 +646,7 @@ class AlluxioClient:
                         worker_host=worker_host,
                         http_port=worker_http_port,
                         path_id=path_id,
+                        file_path=file_path,
                         page_index=page_index,
                     )
                     read_urls.append(page_url)
@@ -665,12 +667,12 @@ class AlluxioClient:
                     f"Error when reading all pages of {path_id}: error {e}"
                 ) from e
 
-    def _all_page_generator(self, worker_host, worker_http_port, path_id):
+    def _all_page_generator(self, worker_host, worker_http_port, path_id, file_path):
         page_index = 0
         while True:
             try:
                 page_content = self._read_page(
-                    worker_host, worker_http_port, path_id, page_index
+                    worker_host, worker_http_port, path_id, file_path, page_index
                 )
             except Exception as e:
                 if page_index == 0:
@@ -688,7 +690,7 @@ class AlluxioClient:
             page_index += 1
 
     def _range_page_generator_alluxiocommon(
-        self, worker_host, worker_http_port, path_id, offset, length
+        self, worker_host, worker_http_port, path_id, file_path, offset, length
     ):
         read_urls = []
         start = offset
@@ -704,6 +706,7 @@ class AlluxioClient:
                     worker_host=worker_host,
                     http_port=worker_http_port,
                     path_id=path_id,
+                    file_path=file_path,
                     page_index=page_index,
                 )
             else:
@@ -711,6 +714,7 @@ class AlluxioClient:
                     worker_host=worker_host,
                     http_port=worker_http_port,
                     path_id=path_id,
+                    file_path=file_path,
                     page_index=page_index,
                     page_offset=inpage_off,
                     page_length=inpage_read_len,
@@ -721,7 +725,7 @@ class AlluxioClient:
         return data
 
     def _range_page_generator(
-        self, worker_host, worker_http_port, path_id, offset, length
+        self, worker_host, worker_http_port, path_id, file_path, offset, length
     ):
         start_page_index = offset // self.page_size
         start_page_offset = offset % self.page_size
@@ -747,6 +751,7 @@ class AlluxioClient:
                     worker_host,
                     worker_http_port,
                     path_id,
+                    file_path,
                     page_index,
                     read_offset,
                     read_length,
@@ -865,6 +870,7 @@ class AlluxioClient:
         worker_host,
         worker_http_port,
         path_id,
+        file_path,
         page_index,
         offset=None,
         length=None,
@@ -880,6 +886,7 @@ class AlluxioClient:
                     worker_host=worker_host,
                     http_port=worker_http_port,
                     path_id=path_id,
+                    file_path=file_path,
                     page_index=page_index,
                 )
                 logger.debug(f"Reading full page request {page_url}")
@@ -888,6 +895,7 @@ class AlluxioClient:
                     worker_host=worker_host,
                     http_port=worker_http_port,
                     path_id=path_id,
+                    file_path=file_path,
                     page_index=page_index,
                     page_offset=offset,
                     page_length=length,
@@ -1198,7 +1206,7 @@ class AlluxioAsyncFileSystem:
         worker_host = self._get_preferred_worker_host(file_path)
         path_id = self._get_path_hash(file_path)
         page_contents = await self._range_page_generator(
-            worker_host, path_id, offset, length
+            worker_host, path_id, file_path, offset, length
         )
         return b"".join(await page_contents)
 
@@ -1226,6 +1234,7 @@ class AlluxioAsyncFileSystem:
                 worker_host=worker_host,
                 http_port=self.http_port,
                 path_id=path_id,
+                file_path=file_path,
                 page_index=page_index,
             ),
             headers={"Content-Type": "application/octet-stream"},
@@ -1234,7 +1243,7 @@ class AlluxioAsyncFileSystem:
         return 200 <= status < 300
 
     async def _range_page_generator(
-        self, worker_host: str, path_id: str, offset: float, length: float
+        self, worker_host: str, path_id: str, file_path: str, offset: float, length: float
     ):
         start_page_index = offset // self.page_size
         start_page_offset = offset % self.page_size
@@ -1257,6 +1266,7 @@ class AlluxioAsyncFileSystem:
                 page_content = self._read_page(
                     worker_host,
                     path_id,
+                    file_path,
                     page_index,
                     start_page_offset,
                     read_length,
@@ -1264,12 +1274,12 @@ class AlluxioAsyncFileSystem:
                 page_contents.append(page_content)
             elif page_index == end_page_index:
                 page_content = self._read_page(
-                    worker_host, path_id, page_index, 0, end_page_read_to
+                    worker_host, path_id, file_path, page_index, 0, end_page_read_to
                 )
                 page_contents.append(page_content)
             else:
                 page_content = self._read_page(
-                    worker_host, path_id, page_index
+                    worker_host, path_id, file_path, page_index
                 )
                 page_contents.append(page_content)
 
@@ -1338,6 +1348,7 @@ class AlluxioAsyncFileSystem:
         self,
         worker_host,
         path_id: str,
+        file_path: str,
         page_index: int,
         offset=None,
         length=None,
@@ -1352,6 +1363,7 @@ class AlluxioAsyncFileSystem:
                 worker_host=worker_host,
                 http_port=self.http_port,
                 path_id=path_id,
+                file_path=file_path,
                 page_index=page_index,
             )
         else:
@@ -1359,6 +1371,7 @@ class AlluxioAsyncFileSystem:
                 worker_host=worker_host,
                 http_port=self.http_port,
                 path_id=path_id,
+                file_path=file_path,
                 page_index=page_index,
                 page_offset=offset,
                 page_length=length,

--- a/alluxiofs/client/core.py
+++ b/alluxiofs/client/core.py
@@ -583,12 +583,22 @@ class AlluxioClient:
         try:
             if self.data_manager:
                 return self._range_page_generator_alluxiocommon(
-                    worker_host, worker_http_port, path_id, file_path, offset, length
+                    worker_host,
+                    worker_http_port,
+                    path_id,
+                    file_path,
+                    offset,
+                    length
                 )
             else:
                 return b"".join(
                     self._range_page_generator(
-                        worker_host, worker_http_port, path_id, file_path, offset, length
+                        worker_host,
+                        worker_http_port,
+                        path_id,
+                        file_path,
+                        offset,
+                        length,
                     )
                 )
         except Exception as e:
@@ -667,12 +677,18 @@ class AlluxioClient:
                     f"Error when reading all pages of {path_id}: error {e}"
                 ) from e
 
-    def _all_page_generator(self, worker_host, worker_http_port, path_id, file_path):
+    def _all_page_generator(
+            self, worker_host, worker_http_port, path_id, file_path
+    ):
         page_index = 0
         while True:
             try:
                 page_content = self._read_page(
-                    worker_host, worker_http_port, path_id, file_path, page_index
+                    worker_host,
+                    worker_http_port,
+                    path_id,
+                    file_path,
+                    page_index
                 )
             except Exception as e:
                 if page_index == 0:
@@ -1243,7 +1259,12 @@ class AlluxioAsyncFileSystem:
         return 200 <= status < 300
 
     async def _range_page_generator(
-        self, worker_host: str, path_id: str, file_path: str, offset: float, length: float
+        self,
+        worker_host: str,
+        path_id: str,
+        file_path: str,
+        offset: float,
+        length: float,
     ):
         start_page_index = offset // self.page_size
         start_page_offset = offset % self.page_size

--- a/alluxiofs/client/core.py
+++ b/alluxiofs/client/core.py
@@ -588,7 +588,7 @@ class AlluxioClient:
                     path_id,
                     file_path,
                     offset,
-                    length
+                    length,
                 )
             else:
                 return b"".join(
@@ -678,7 +678,7 @@ class AlluxioClient:
                 ) from e
 
     def _all_page_generator(
-            self, worker_host, worker_http_port, path_id, file_path
+        self, worker_host, worker_http_port, path_id, file_path
     ):
         page_index = 0
         while True:
@@ -688,7 +688,7 @@ class AlluxioClient:
                     worker_http_port,
                     path_id,
                     file_path,
-                    page_index
+                    page_index,
                 )
             except Exception as e:
                 if page_index == 0:
@@ -1295,7 +1295,12 @@ class AlluxioAsyncFileSystem:
                 page_contents.append(page_content)
             elif page_index == end_page_index:
                 page_content = self._read_page(
-                    worker_host, path_id, file_path, page_index, 0, end_page_read_to
+                    worker_host,
+                    path_id,
+                    file_path,
+                    page_index,
+                    0,
+                    end_page_read_to,
                 )
                 page_contents.append(page_content)
             else:

--- a/alluxiofs/core.py
+++ b/alluxiofs/core.py
@@ -200,100 +200,40 @@ class AlluxioFileSystem(AbstractFileSystem):
             # process path related arguments to remove alluxiofs protocol
             # since both alluxio and ufs cannot process alluxiofs protocol
             # Require s3://bucket/path or /bucket/path
-            # paths may be passed as positional argument or kwarg arguments
-            # process accordingly and keep paths as positional argument if passed as positional,
-            # and keep as kwarg arguments if passed as kwarg.
-
+            bound_args = signature.bind(self, *args, **kwargs)
+            bound_args.apply_defaults()
             # fsspec path parameters has different names and sequences
-            # process all path related parameters
-            possible_path_arg_names = [("path1", "path2"), ("lpath", "rpath")]
-            positional_params = list(args)
-
-            # get a list of arguments defined in the function
-            argument_list = []
-            for param in signature.parameters.values():
-                argument_list.append(param.name)
-
-            if "path" in argument_list:
-                if "path" in kwargs:
-                    kwargs["path"] = self._strip_alluxiofs_protocol(
-                        kwargs["path"]
+            # use this approach to try to process all path related parameters
+            for param in ["path", "path1", "path2", "lpath", "rpath"]:
+                if param in bound_args.arguments:
+                    bound_args.arguments[
+                        param
+                    ] = self._strip_alluxiofs_protocol(
+                        bound_args.arguments[param]
                     )
-                else:
-                    positional_params[0] = self._strip_alluxiofs_protocol(
-                        positional_params[0]
-                    )
-
-            else:
-                for path1, path2 in possible_path_arg_names:
-                    if (path1 in argument_list) and (path2 in argument_list):
-                        if (path1 in kwargs) and (path2 in kwargs):
-                            kwargs[path1] = self._strip_alluxiofs_protocol(
-                                kwargs[path1]
-                            )
-                            kwargs[path2] = self._strip_alluxiofs_protocol(
-                                kwargs[path2]
-                            )
-                        elif (path1 in kwargs) and (path2 not in kwargs):
-                            kwargs[path1] = self._strip_alluxiofs_protocol(
-                                kwargs[path1]
-                            )
-                            path2_index = argument_list.index(path2) - 1
-                            positional_params[
-                                path2_index
-                            ] = self._strip_alluxiofs_protocol(
-                                positional_params[path2_index]
-                            )
-                        elif (path1 not in kwargs) and (path2 in kwargs):
-                            kwargs[path2] = self._strip_alluxiofs_protocol(
-                                kwargs[path2]
-                            )
-                            path1_index = argument_list.index(path1) - 1
-                            positional_params[
-                                path1_index
-                            ] = self._strip_alluxiofs_protocol(
-                                positional_params[path1_index]
-                            )
-                        else:
-                            path1_index = argument_list.index(path1) - 1
-                            positional_params[
-                                path1_index
-                            ] = self._strip_alluxiofs_protocol(
-                                positional_params[path1_index]
-                            )
-                            path2_index = argument_list.index(path2) - 1
-                            positional_params[
-                                path2_index
-                            ] = self._strip_alluxiofs_protocol(
-                                positional_params[path2_index]
-                            )
-
-            positional_params = tuple(positional_params)
 
             try:
                 if self.alluxio:
                     start_time = time.time()
-                    res = alluxio_impl(self, *positional_params, **kwargs)
+                    res = alluxio_impl(*bound_args.args, **bound_args.kwargs)
                     logger.debug(
-                        f"Exit(Ok): alluxio op({alluxio_impl.__name__}) args({positional_params}) kwargs({kwargs}) time({(time.time() - start_time):.2f}s)"
+                        f"Exit(Ok): alluxio op({alluxio_impl.__name__}) args({bound_args.args}) kwargs({bound_args.kwargs}) time({(time.time() - start_time):.2f}s)"
                     )
                     return res
             except Exception as e:
                 if not isinstance(e, NotImplementedError):
                     logger.debug(
-                        f"Exit(Error): alluxio op({alluxio_impl.__name__}) args({positional_params}) kwargs({kwargs}) {e}"
+                        f"Exit(Error): alluxio op({alluxio_impl.__name__}) args({bound_args.args}) kwargs({bound_args.kwargs}) {e}"
                     )
                     self.error_metrics.record_error(alluxio_impl.__name__, e)
                 if self.fs is None:
                     raise e
 
             fs_method = getattr(self.fs, alluxio_impl.__name__, None)
-
             if fs_method:
-                res = fs_method(*positional_params, **kwargs)
-
+                res = fs_method(*bound_args.args[1:], **bound_args.kwargs)
                 logger.debug(
-                    f"Exit(Ok): ufs({self.target_protocol}) op({alluxio_impl.__name__}) args({positional_params}) kwargs({kwargs})"
+                    f"Exit(Ok): ufs({self.target_protocol}) op({alluxio_impl.__name__}) args({bound_args.args}) kwargs({bound_args.kwargs})"
                 )
                 return res
             raise NotImplementedError(

--- a/benchmark/bench/AlluxioRESTBench.py
+++ b/benchmark/bench/AlluxioRESTBench.py
@@ -139,6 +139,7 @@ class AlluxioRESTBench(AbstractBench):
                     worker_host=self.worker_host,
                     http_port=ALLUXIO_WORKER_HTTP_SERVER_PORT_DEFAULT_VALUE,
                     path_id=self.args.fileid,
+                    file_path=self.args.path,
                     page_index=page_idx,
                 )
             )

--- a/tests/client/test_fake_server.py
+++ b/tests/client/test_fake_server.py
@@ -42,12 +42,8 @@ def server(event_loop):
 
     app = web.Application()
     app.on_startup.append(startup)
-    app.router.add_get(
-        PAGE_PATH_URL_FORMAT, get_file_handler
-    )
-    app.router.add_post(
-        PAGE_PATH_URL_FORMAT, put_file_handler
-    )
+    app.router.add_get(PAGE_PATH_URL_FORMAT, get_file_handler)
+    app.router.add_post(PAGE_PATH_URL_FORMAT, put_file_handler)
     server = TestServer(app)
     event_loop.run_until_complete(server.start_server())
     return server

--- a/tests/client/test_fake_server.py
+++ b/tests/client/test_fake_server.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.asyncio
 def server(event_loop):
     async def get_file_handler(request: web.Request) -> web.Response:
         alluxio: dict = request.app["alluxio"]
-        bytes = alluxio[request.match_info["file_path"]][
+        bytes = alluxio[request.match_info["path_id"]][
             request.match_info["page_index"]
         ]
 
@@ -28,12 +28,12 @@ def server(event_loop):
     async def put_file_handler(request: web.Request) -> web.Response:
         data = await request.read()
         alluxio: dict = request.app["alluxio"]
-        alluxio[request.match_info["file_path"]] = {
+        alluxio[request.match_info["path_id"]] = {
             request.match_info["page_index"]: data
         }
         return web.json_response(
             {
-                "file_path": request.match_info["file_path"],
+                "path_id": request.match_info["path_id"],
             }
         )
 

--- a/tests/client/test_fake_server.py
+++ b/tests/client/test_fake_server.py
@@ -5,6 +5,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestServer
 
 from alluxiofs.client import AlluxioAsyncFileSystem
+from alluxiofs.client.const import PAGE_PATH_URL_FORMAT
 
 pytestmark = pytest.mark.asyncio
 
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.asyncio
 def server(event_loop):
     async def get_file_handler(request: web.Request) -> web.Response:
         alluxio: dict = request.app["alluxio"]
-        bytes = alluxio[request.match_info["path_id"]][
+        bytes = alluxio[request.match_info["file_path"]][
             request.match_info["page_index"]
         ]
 
@@ -27,12 +28,12 @@ def server(event_loop):
     async def put_file_handler(request: web.Request) -> web.Response:
         data = await request.read()
         alluxio: dict = request.app["alluxio"]
-        alluxio[request.match_info["path_id"]] = {
+        alluxio[request.match_info["file_path"]] = {
             request.match_info["page_index"]: data
         }
         return web.json_response(
             {
-                "path_id": request.match_info["path_id"],
+                "file_path": request.match_info["file_path"],
             }
         )
 
@@ -42,10 +43,10 @@ def server(event_loop):
     app = web.Application()
     app.on_startup.append(startup)
     app.router.add_get(
-        "/v1/file/{path_id}/page/{page_index}", get_file_handler
+        PAGE_PATH_URL_FORMAT, get_file_handler
     )
     app.router.add_post(
-        "/v1/file/{path_id}/page/{page_index}", put_file_handler
+        PAGE_PATH_URL_FORMAT, put_file_handler
     )
     server = TestServer(app)
     event_loop.run_until_complete(server.start_server())


### PR DESCRIPTION
In Alluxio 3.3, we use the ufs full path as the fileId, instead of a hash String. It breaks the fsspec/alluxiofs, this PR is used to fix the bugs.